### PR TITLE
restructured apb_mod

### DIFF
--- a/kerdesek.md
+++ b/kerdesek.md
@@ -1,0 +1,24 @@
+## Maj 2
+
++ jo helyen van a memoria a ket modul kozott? vagy inkabb vezerlojelek amba -> i2c
+  + regiszterek es NEM memoria!
+  + ossz 1 db 32 bites regiszter!
+  + regiszter inkabb I2C modulban (inout)
+
++ PU? hogyan szimulaljuk az olvasast?
+  + a `pullup()` okes 
+  + butan beirjuk az ACK jeleket kezzel
+
++ cimtartomany? a sajat memoriankat hova rakjuk a 32bithez kepest?
+    + mondjuk 0x80000000 on van a periferia kezdocime, onnan rekeszek 4byteonkent
+    + regiszterek 32bitesek!!
+
++ szinkron reset!
+
++ teszteles? kell kulon-kulon, vagy egybe mukodes?
+  + eleg egybe
+
++ doksi kimerte, reszletessege
+  + max 20 oldal, AMBA, I2C bevezetes
+
++ szintetizalhatosag nem szempont, csak szimulacioban legyen ok!

--- a/project/HW.xise
+++ b/project/HW.xise
@@ -29,10 +29,6 @@
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="2"/>
     </file>
-    <file xil_pn:name="mod_APB.v" xil_pn:type="FILE_VERILOG">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
-    </file>
     <file xil_pn:name="mod_I2C.v" xil_pn:type="FILE_VERILOG">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="1"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="1"/>
@@ -69,7 +65,7 @@
     <property xil_pn:name="Change Device Speed To" xil_pn:value="-4" xil_pn:valueState="default"/>
     <property xil_pn:name="Change Device Speed To Post Trace" xil_pn:value="-4" xil_pn:valueState="default"/>
     <property xil_pn:name="Combinatorial Logic Optimization" xil_pn:value="false" xil_pn:valueState="default"/>
-    <property xil_pn:name="Compile EDK Simulation Library" xil_pn:value="true" xil_pn:valueState="non-default"/>
+    <property xil_pn:name="Compile EDK Simulation Library" xil_pn:value="true" xil_pn:valueState="default"/>
     <property xil_pn:name="Compile SIMPRIM (Timing) Simulation Library" xil_pn:value="true" xil_pn:valueState="default"/>
     <property xil_pn:name="Compile UNISIM (Functional) Simulation Library" xil_pn:value="true" xil_pn:valueState="default"/>
     <property xil_pn:name="Compile XilinxCoreLib (CORE Generator) Simulation Library" xil_pn:value="true" xil_pn:valueState="default"/>

--- a/project/HW.xise
+++ b/project/HW.xise
@@ -16,25 +16,25 @@
 
   <files>
     <file xil_pn:name="mod_top.v" xil_pn:type="FILE_VERILOG">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="3"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="3"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
     </file>
     <file xil_pn:name="tb_top.v" xil_pn:type="FILE_VERILOG">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="4"/>
       <association xil_pn:name="PostMapSimulation" xil_pn:seqID="45"/>
       <association xil_pn:name="PostRouteSimulation" xil_pn:seqID="45"/>
       <association xil_pn:name="PostTranslateSimulation" xil_pn:seqID="45"/>
     </file>
     <file xil_pn:name="apb_mod.v" xil_pn:type="FILE_VERILOG">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="2"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="2"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="1"/>
     </file>
     <file xil_pn:name="mod_I2C.v" xil_pn:type="FILE_VERILOG">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="1"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="1"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
     </file>
     <file xil_pn:name="I2C_test.v" xil_pn:type="FILE_VERILOG">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="2"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="PostMapSimulation" xil_pn:seqID="18"/>
       <association xil_pn:name="PostRouteSimulation" xil_pn:seqID="18"/>
       <association xil_pn:name="PostTranslateSimulation" xil_pn:seqID="18"/>
@@ -267,8 +267,8 @@
     <property xil_pn:name="Run for Specified Time Translate" xil_pn:value="true" xil_pn:valueState="default"/>
     <property xil_pn:name="Safe Implementation" xil_pn:value="No" xil_pn:valueState="default"/>
     <property xil_pn:name="Security" xil_pn:value="Enable Readback and Reconfiguration" xil_pn:valueState="default"/>
-    <property xil_pn:name="Selected Module Instance Name" xil_pn:value="/I2C_test" xil_pn:valueState="non-default"/>
-    <property xil_pn:name="Selected Simulation Root Source Node Behavioral" xil_pn:value="work.I2C_test" xil_pn:valueState="non-default"/>
+    <property xil_pn:name="Selected Module Instance Name" xil_pn:value="/tb_top" xil_pn:valueState="non-default"/>
+    <property xil_pn:name="Selected Simulation Root Source Node Behavioral" xil_pn:value="work.tb_top" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Selected Simulation Root Source Node Post-Map" xil_pn:value="" xil_pn:valueState="default"/>
     <property xil_pn:name="Selected Simulation Root Source Node Post-Route" xil_pn:value="" xil_pn:valueState="default"/>
     <property xil_pn:name="Selected Simulation Root Source Node Post-Translate" xil_pn:value="" xil_pn:valueState="default"/>
@@ -284,7 +284,7 @@
     <property xil_pn:name="Slice Packing" xil_pn:value="true" xil_pn:valueState="default"/>
     <property xil_pn:name="Slice Utilization Ratio" xil_pn:value="100" xil_pn:valueState="default"/>
     <property xil_pn:name="Specify 'define Macro Name and Value" xil_pn:value="" xil_pn:valueState="default"/>
-    <property xil_pn:name="Specify Top Level Instance Names Behavioral" xil_pn:value="work.I2C_test" xil_pn:valueState="default"/>
+    <property xil_pn:name="Specify Top Level Instance Names Behavioral" xil_pn:value="work.tb_top" xil_pn:valueState="default"/>
     <property xil_pn:name="Specify Top Level Instance Names Post-Map" xil_pn:value="Default" xil_pn:valueState="default"/>
     <property xil_pn:name="Specify Top Level Instance Names Post-Route" xil_pn:value="Default" xil_pn:valueState="default"/>
     <property xil_pn:name="Specify Top Level Instance Names Post-Translate" xil_pn:value="Default" xil_pn:valueState="default"/>
@@ -334,7 +334,7 @@
     <!--                                                                                  -->
     <!-- The following properties are for internal use only. These should not be modified.-->
     <!--                                                                                  -->
-    <property xil_pn:name="PROP_BehavioralSimTop" xil_pn:value="Module|I2C_test" xil_pn:valueState="non-default"/>
+    <property xil_pn:name="PROP_BehavioralSimTop" xil_pn:value="Module|tb_top" xil_pn:valueState="non-default"/>
     <property xil_pn:name="PROP_DesignName" xil_pn:value="HW" xil_pn:valueState="non-default"/>
     <property xil_pn:name="PROP_DevFamilyPMName" xil_pn:value="spartan3" xil_pn:valueState="default"/>
     <property xil_pn:name="PROP_FPGAConfiguration" xil_pn:value="FPGAConfiguration" xil_pn:valueState="default"/>

--- a/project/apb_mod.v
+++ b/project/apb_mod.v
@@ -27,15 +27,15 @@ module apb_mod
     input reset,
     input [`addrWidth-1:0] addr,
     input [`dataWidth-1:0] pwdata,
-    output reg [`dataWidth:0] prdata,
+    output reg [`dataWidth-1:0] prdata,
     input pwrite,
     input psel,
-    input penable,
+    input penable/*,
 	 output reg startbit,
 	 output reg resetbit,
 	 output reg it_enable,
 	 output reg [`dataWidth-1:0]per_addr,
-	 output reg [`dataWidth-1:0]per_data
+	 output reg [`dataWidth-1:0]per_data*/
     );
 
 /*reg [7:0] clk_counter;
@@ -46,53 +46,61 @@ integer i;
 
 reg [`dataWidth-1:0] mem [`addrWidth-1:0];
 
-always @ (posedge clk or negedge reset) begin
-	/*clk_counter <= clk_counter + 1;
-	prdata <= clk_counter;*/
-	if (reset == 0) begin
-		apb_status = 0;
-		prdata <= 0;
-		for (i=0; i<=`addrWidth; i=i+1) begin
-			mem[i] = 0;
-		end
+always @ (negedge reset) begin // reset block
+	apb_status <= 0;
+	prdata <= 0;
+	for (i=0; i<`addrWidth; i=i+1) begin
+		mem[i] <= 0;
 	end
-	else
-		if (psel == 0)
-			apb_status = 0;
-		else
-			if (penable == 0)
-				apb_status = 1;
-			else
-				if (pwrite == 0)
-					apb_status = 2;
-				else
-					apb_status = 3;
-	
+end
+
+always @(apb_status) begin	// combinatorial block
 	if (apb_status == 2)
-		prdata = mem[addr];
+		prdata <= mem[addr];
 	else if (apb_status == 3)
-		mem[addr] = pwdata;
+		mem[addr] <= pwdata;
+end
+
+always @ (posedge clk) begin	// clocked block
+	if (psel == 0)
+		apb_status <= 0;
+	else begin
+		if (penable == 0)
+			apb_status <= 1;
+		else
+			if (pwrite == 0)
+				apb_status <= 2;	//read
+			else
+				apb_status <= 3;	//write
+	end
 	
-	startbit = mem[0];
-	resetbit = mem[1];
-	it_enable = mem[2];
-	per_addr = mem[3];
-	per_data = mem[4];
+	/*
+	//startbit <= mem[0];
+	assign startbit = mem[0];
+	//resetbit <= mem[1];
+	assign resetbit = mem[1];
+	//it_enable <= mem[2];
+	assign it_enable = mem[2];
+	//per_addr <= mem[3];
+	assign per_addr = mem[3];
+	//per_data <= mem[4];
+	assign per_data = mem[4];*/
 
 /*	$display("Status is: %d", apb_status);
 	//$display("int: %d", addr_int);
 
 	for (i=0; i<addrWidth; i=i+1)
 		$display("Mem %d: %d",i,mem[i]);	
-	$display("------------------------");*/
+	$display("------------------------");
 	
+
 	$display("startbit: %d",startbit);
 	$display("resetbit: %d",resetbit);	
 	$display("it_enable: %d",it_enable);	
 	$display("per_addr: %d",per_addr);	
 	$display("per_data: %d",per_data);	
 	$display("------------------------");
-
+	*/
 end
 
 endmodule

--- a/project/macros.vh
+++ b/project/macros.vh
@@ -20,7 +20,7 @@
 `ifndef macros_vh
 `define macros_vh
 
-`define addrWidth 8
+`define addrWidth 32
 `define dataWidth 32
 
 `endif

--- a/project/mod_I2C.v
+++ b/project/mod_I2C.v
@@ -103,7 +103,7 @@ begin
 		
 		START :
 		begin
-			rSDA = 0; //pull down the wire
+			rSDA <= 0; //pull down the wire
 			
 			if (cnt == div) //divided clock -> toggle the scl
 			begin
@@ -113,7 +113,7 @@ begin
 				
 				byteCounter <= 0;
 				read <= address[7];
-				states = WRITE_ADDR; //go to the next state
+				states <= WRITE_ADDR; //go to the next state
 			end
 			else
 			begin
@@ -314,6 +314,7 @@ end
 
 
 // Open Drain assignment
+//pullup(SDA); //for simulation only!
 assign SDA = rSDA ? 1'bz : 1'b0;
 assign SCL = rSCL;
 //assign SCL = rSCL ? 1'bz : 1'b0;

--- a/project/mod_top.v
+++ b/project/mod_top.v
@@ -47,22 +47,18 @@ module mod_top
 	wire [`dataWidth-1:0] per_addr; //azert datawith nem pedig addrwith mert ez az i2c periferiaira vonatkozik
 	wire [`dataWidth-1:0] per_data;
 	
-apb_mod amp_instance (
+// Instantiate the module
+apb_mod inst_APB (
     .clk(PCLK), 
     .reset(PRESETn), 
-    .addr(PADDR), 
+    .paddr(PADDR), 
     .pwdata(PWDATA), 
     .prdata(PRDATA), 
     .pwrite(PWRITE), 
     .psel(PSELx), 
-    .penable(PENABLE)/*,
-    .startbit(startbit), 
-    .resetbit(resetbit), 
-    .it_enable(it_enable), 
-    .per_addr(per_addr), 
-    .per_data(per_data)*/
+    .penable(PENABLE), 
+    .perdata(perdata)
     );
-	 // should just connect to mem, as the mod_I2c
 	 
 // Instantiate the module
 mod_I2C instance_name (
@@ -75,9 +71,5 @@ mod_I2C instance_name (
     .rst(rst), 
     .ready(ready)
     );
-	 
-// Instantiate pullup
-PULLUP PU_SDA (
-.O(SDA)); 
 	 
 endmodule

--- a/project/mod_top.v
+++ b/project/mod_top.v
@@ -32,7 +32,9 @@ module mod_top
 	input 			PENABLE,   // This strobe signal is used to time all accesses on the peripheral bus. The enable signal is used to indicate the second cycle of an APB transfer. The rising edge of PENABLE occurs in the middle of the APB transfer.
 	input 			PWRITE,    // When HIGH this signal indicates an APB write access and when LOW a read access.
 	output	[`dataWidth-1:0]	PRDATA,    // The read data bus is driven by the selected slave during read cycles (when PWRITE is LOW). The read data bus can be up to 32-bits wide.
-	input 	[`dataWidth-1:0] 	PWDATA     // The write data bus is driven by the peripheral bus bridge unit during write cycles (when PWRITE is HIGH). The write data bus can be up to 32-bits wide.
+	input 	[`dataWidth-1:0] 	PWDATA,     // The write data bus is driven by the peripheral bus bridge unit during write cycles (when PWRITE is HIGH). The write data bus can be up to 32-bits wide.
+	inout SDA,
+	output SCL
 );
 
 // apb_mod
@@ -53,13 +55,14 @@ apb_mod amp_instance (
     .prdata(PRDATA), 
     .pwrite(PWRITE), 
     .psel(PSELx), 
-    .penable(PENABLE),
+    .penable(PENABLE)/*,
     .startbit(startbit), 
     .resetbit(resetbit), 
     .it_enable(it_enable), 
     .per_addr(per_addr), 
-    .per_data(per_data)
+    .per_data(per_data)*/
     );
+	 // should just connect to mem, as the mod_I2c
 	 
 // Instantiate the module
 mod_I2C instance_name (
@@ -72,19 +75,9 @@ mod_I2C instance_name (
     .rst(rst), 
     .ready(ready)
     );
-
-/*reg [31:0] cntr;
-
-always @ (posedge PCLK) begin
-	if (!PRESETn)
-		cntr <= 0;
-	else if (PENABLE)
-		if (PSELx)
-			cntr <= cntr + 1;
-		else
-			cntr <= cntr - 1;
-end*/
-
-assign PRDATA = prdata;
-
+	 
+// Instantiate pullup
+PULLUP PU_SDA (
+.O(SDA)); 
+	 
 endmodule

--- a/project/tb_top.v
+++ b/project/tb_top.v
@@ -68,8 +68,8 @@ module tb_top();
 		#10 PRESETn = 0;
 		#80 PRESETn = 1;
 		
-		// 1-es (resetbit) cimbe 1 bersa
-		#40 PADDR = 1; PWDATA = 1;
+		// kezdocimre 1 beirasa
+		#40 PADDR = 0'h80000000; PWDATA = 1;
 		#5 PWRITE = 1;
 		#10 PSELx = 1;
 		#25 //penable csak kovetkezo ciklusban!
@@ -81,25 +81,28 @@ module tb_top();
 		
 		#40
 		
-		//
-		// 4-es (per_data) cimbe 144 bersa
-		#10 PADDR = 4;
-		#10 PWDATA = 144;
+		//kiolvasas
+		#10 PWRITE = 0;
 		#10 PSELx = 1;
 		#10 PENABLE = 1;
-
+		
 		#40
 		
 		//to idle
 		#10 PENABLE = 0;
 		#10 PSELx = 0;
 		
-		#40
-		
-		//kilvasas
-		#10 PWRITE = 0;
+		//
+		// ervenytelen cimbe iras
+		#10 PADDR = 0'h80000004;
+		#10 PWDATA = 144;
 		#10 PSELx = 1;
 		#10 PENABLE = 1;
+
+		#40
+		
+		
+		
 		
 		#100
 		


### PR DESCRIPTION
fixed some blocking assignment in mod_I2C, now valid for synthesis. Also added a pullup at mod_top, sadly this is only present in RTL, but in turn, "pullup()" is effective in simulation!